### PR TITLE
fix: plugin name in code and doc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,11 +25,11 @@ start: build
 
 .PHONY: enable
 enable:
-	vault auth enable -path=multirole-jwt vault-plugin-auth-jwt-auto-roles
+	vault auth enable -path=jwt-auto-roles vault-plugin-auth-jwt-auto-roles
 
 .PHONY: disable
 disable:
-	vault auth disable multirole-jwt
+	vault auth disable jwt-auto-roles
 	vault plugin deregister auth vault-plugin-auth-jwt-auto-roles
 
 auth=jwt
@@ -42,7 +42,7 @@ config:
 
 .PHONY: configure
 configure:
-	vault write auth/multirole-jwt/config @config.json
+	vault write auth/jwt-auto-roles/config @config.json
 
 .PHONY: clean
 clean:

--- a/internal/jwtauth/backend.go
+++ b/internal/jwtauth/backend.go
@@ -16,8 +16,8 @@ import (
 
 const (
 	backendHelp = `
-The JWT auto roles auth plugin allows authentication with multiple auto-detected
-roles using JWTs (including OIDC).
+The JWT auto roles auth plugin allows automatic authentication with all roles
+matching a JWT (or OIDC) token.
 `
 	vaultClientTimeoutSeconds = 5
 )

--- a/internal/jwtauth/backend.go
+++ b/internal/jwtauth/backend.go
@@ -16,7 +16,8 @@ import (
 
 const (
 	backendHelp = `
-The multirole JWT backend plugin allows authentication with multiple roles using JWTs (including OIDC).
+The JWT auto roles auth plugin allows authentication with multiple auto-detected
+roles using JWTs (including OIDC).
 `
 	vaultClientTimeoutSeconds = 5
 )
@@ -29,11 +30,11 @@ func Factory(ctx context.Context, c *logical.BackendConfig) (logical.Backend, er
 	return b, nil
 }
 
-type multiroleJWTAuthBackend struct {
+type jwtAutoRolesAuthBackend struct {
 	*framework.Backend
 
 	l            sync.RWMutex
-	cachedConfig *multiroleJWTConfig
+	cachedConfig *jwtAutoRolesConfig
 	roleIndex    *roleIndex
 	policyClient policyFetcher
 }
@@ -42,8 +43,8 @@ type policyFetcher interface {
 	policies(ctx context.Context, request schema.JwtLoginRequest) ([]string, error)
 }
 
-func backend(_ *logical.BackendConfig) *multiroleJWTAuthBackend {
-	var backend multiroleJWTAuthBackend
+func backend(_ *logical.BackendConfig) *jwtAutoRolesAuthBackend {
+	var backend jwtAutoRolesAuthBackend
 	backend.Backend = &framework.Backend{
 		BackendType: logical.TypeCredential,
 		Help:        backendHelp,
@@ -59,14 +60,14 @@ func backend(_ *logical.BackendConfig) *multiroleJWTAuthBackend {
 	return &backend
 }
 
-func (b *multiroleJWTAuthBackend) reset() {
+func (b *jwtAutoRolesAuthBackend) reset() {
 	b.l.Lock()
 	defer b.l.Unlock()
 	b.cachedConfig = nil
 	b.roleIndex = nil
 }
 
-func (b *multiroleJWTAuthBackend) getRoleIndex(config *multiroleJWTConfig) (*roleIndex, error) {
+func (b *jwtAutoRolesAuthBackend) getRoleIndex(config *jwtAutoRolesConfig) (*roleIndex, error) {
 	b.l.Lock()
 	defer b.l.Unlock()
 
@@ -83,7 +84,7 @@ func (b *multiroleJWTAuthBackend) getRoleIndex(config *multiroleJWTConfig) (*rol
 	return index, nil
 }
 
-func (b *multiroleJWTAuthBackend) getPolicyClient(config *multiroleJWTConfig) (policyFetcher, error) {
+func (b *jwtAutoRolesAuthBackend) getPolicyClient(config *jwtAutoRolesConfig) (policyFetcher, error) {
 	b.l.Lock()
 	defer b.l.Unlock()
 

--- a/internal/jwtauth/backend_utils_test.go
+++ b/internal/jwtauth/backend_utils_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
-func createTestBackend(t *testing.T) (*multiroleJWTAuthBackend, logical.Storage) {
+func createTestBackend(t *testing.T) (*jwtAutoRolesAuthBackend, logical.Storage) {
 	config := &logical.BackendConfig{
 		Logger: logging.NewVaultLogger(log.Trace),
 
@@ -26,9 +26,9 @@ func createTestBackend(t *testing.T) (*multiroleJWTAuthBackend, logical.Storage)
 		t.Fatalf("unable to create backend: %v", err)
 	}
 
-	backend, ok := logicalBackend.(*multiroleJWTAuthBackend)
+	backend, ok := logicalBackend.(*jwtAutoRolesAuthBackend)
 	if !ok {
-		t.Fatal("backend is not a multiroleJWTAuthBackend")
+		t.Fatal("backend is not a jwtAutoRolesAuthBackend")
 	}
 
 	return backend, config.StorageView

--- a/internal/jwtauth/path_config.go
+++ b/internal/jwtauth/path_config.go
@@ -12,15 +12,15 @@ const (
 	configPath string = "config"
 
 	pathConfigHelpSyn = `
-Configures the multirole JWT authentication backend.
+Configures the JWT auto roles authentication backend.
 `
 	pathConfigHelpDesc = `
-The multirole JWT authentication backend uses configured bound claims of another
+The JWT auto roles authentication backend uses configured bound claims of another
 jwt auth backends's roles to quickly deduce which roles an incoming jwt unlocks.
 `
 )
 
-type multiroleJWTConfig struct {
+type jwtAutoRolesConfig struct {
 	// Roles map role names to bound claims. Bound claims must be of type
 	// map[string][]string.
 	Roles       map[string]any `json:"roles"`
@@ -28,7 +28,7 @@ type multiroleJWTConfig struct {
 	JWTAuthPath string         `json:"jwt_auth_path"`
 }
 
-func pathConfig(backend *multiroleJWTAuthBackend) *framework.Path {
+func pathConfig(backend *jwtAutoRolesAuthBackend) *framework.Path {
 	return &framework.Path{
 		Pattern: `config`,
 		Fields: map[string]*framework.FieldSchema{
@@ -55,15 +55,15 @@ func pathConfig(backend *multiroleJWTAuthBackend) *framework.Path {
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.ReadOperation: &framework.PathOperation{
 				Callback: backend.pathConfigRead,
-				Summary:  "Read the current multirole JWT authentication backend configuration.",
+				Summary:  "Read the current JWT auto roles authentication backend configuration.",
 			},
 			logical.UpdateOperation: &framework.PathOperation{
 				Callback: backend.pathConfigWrite,
-				Summary:  "Configure the multirole JWT authentication backend.",
+				Summary:  "Configure the JWT auto roles authentication backend.",
 			},
 			logical.DeleteOperation: &framework.PathOperation{
 				Callback: backend.pathConfigDelete,
-				Summary:  "Delete the multirole JWT authentication backend config.",
+				Summary:  "Delete the JWT auto roles authentication backend config.",
 			},
 		},
 
@@ -72,7 +72,7 @@ func pathConfig(backend *multiroleJWTAuthBackend) *framework.Path {
 	}
 }
 
-func (b *multiroleJWTAuthBackend) config(ctx context.Context, storage logical.Storage) (*multiroleJWTConfig, error) {
+func (b *jwtAutoRolesAuthBackend) config(ctx context.Context, storage logical.Storage) (*jwtAutoRolesConfig, error) {
 	if b.cachedConfig != nil {
 		return b.cachedConfig, nil
 	}
@@ -88,7 +88,7 @@ func (b *multiroleJWTAuthBackend) config(ctx context.Context, storage logical.St
 		return nil, nil
 	}
 
-	config := &multiroleJWTConfig{}
+	config := &jwtAutoRolesConfig{}
 	if err := entry.DecodeJSON(config); err != nil {
 		return nil, err
 	}
@@ -97,10 +97,10 @@ func (b *multiroleJWTAuthBackend) config(ctx context.Context, storage logical.St
 	return config, nil
 }
 
-func (b *multiroleJWTAuthBackend) pathConfigWrite(
+func (b *jwtAutoRolesAuthBackend) pathConfigWrite(
 	ctx context.Context, req *logical.Request, d *framework.FieldData,
 ) (*logical.Response, error) {
-	config := multiroleJWTConfig{
+	config := jwtAutoRolesConfig{
 		Roles:       d.Get("roles").(map[string]any),
 		JWTAuthHost: d.Get("jwt_auth_host").(string),
 		JWTAuthPath: d.Get("jwt_auth_path").(string),
@@ -123,7 +123,7 @@ func (b *multiroleJWTAuthBackend) pathConfigWrite(
 	return nil, nil
 }
 
-func (b *multiroleJWTAuthBackend) pathConfigRead(
+func (b *jwtAutoRolesAuthBackend) pathConfigRead(
 	ctx context.Context, req *logical.Request, d *framework.FieldData,
 ) (*logical.Response, error) {
 	config, err := b.config(ctx, req.Storage)
@@ -143,7 +143,7 @@ func (b *multiroleJWTAuthBackend) pathConfigRead(
 	}, nil
 }
 
-func (b *multiroleJWTAuthBackend) pathConfigDelete(
+func (b *jwtAutoRolesAuthBackend) pathConfigDelete(
 	ctx context.Context, req *logical.Request, d *framework.FieldData,
 ) (*logical.Response, error) {
 	err := req.Storage.Delete(ctx, configPath)

--- a/internal/jwtauth/path_config_test.go
+++ b/internal/jwtauth/path_config_test.go
@@ -31,7 +31,7 @@ func TestConfig_Write(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expected := &multiroleJWTConfig{
+	expected := &jwtAutoRolesConfig{
 		Roles:       configData["roles"].(map[string]any),
 		JWTAuthHost: "http://localhost:8200",
 		JWTAuthPath: "foo/jwt",

--- a/internal/jwtauth/path_login.go
+++ b/internal/jwtauth/path_login.go
@@ -20,7 +20,7 @@ Authenticates JWTs.
 `
 )
 
-func pathLogin(backend *multiroleJWTAuthBackend) *framework.Path {
+func pathLogin(backend *jwtAutoRolesAuthBackend) *framework.Path {
 	return &framework.Path{
 		Pattern: "login",
 		Fields: map[string]*framework.FieldSchema{
@@ -40,7 +40,7 @@ func pathLogin(backend *multiroleJWTAuthBackend) *framework.Path {
 	}
 }
 
-func (b *multiroleJWTAuthBackend) pathLogin(
+func (b *jwtAutoRolesAuthBackend) pathLogin(
 	ctx context.Context, req *logical.Request, d *framework.FieldData,
 ) (*logical.Response, error) {
 	token := d.Get("jwt").(string)
@@ -82,8 +82,8 @@ func (b *multiroleJWTAuthBackend) pathLogin(
 
 // policies use the token to log in to the configured auth backend for each
 // role, and returns the aggregated policies of successful logins.
-func (b *multiroleJWTAuthBackend) policies(
-	ctx context.Context, config *multiroleJWTConfig, roles []string, token string,
+func (b *jwtAutoRolesAuthBackend) policies(
+	ctx context.Context, config *jwtAutoRolesConfig, roles []string, token string,
 ) ([]string, error) {
 	client, err := b.getPolicyClient(config)
 	if err != nil {

--- a/internal/jwtauth/role_index.go
+++ b/internal/jwtauth/role_index.go
@@ -10,7 +10,7 @@ type roleIndex struct {
 	jwtMatcher *node
 }
 
-func createRoleIndex(config *multiroleJWTConfig) (*roleIndex, error) {
+func createRoleIndex(config *jwtAutoRolesConfig) (*roleIndex, error) {
 	roles, err := parseRoles(config)
 	if err != nil {
 		return nil, err
@@ -26,7 +26,7 @@ func (ri *roleIndex) claimsRoles(claims map[string]any) []string {
 	return ri.jwtMatcher.findBoundRoleNames(claims)
 }
 
-func parseRoles(config *multiroleJWTConfig) (roles, error) {
+func parseRoles(config *jwtAutoRolesConfig) (roles, error) {
 	roles := make(roles)
 	for roleName, bc := range config.Roles {
 		boundClaims, err := parseBoundClaims(bc)

--- a/internal/jwtauth/role_index_test.go
+++ b/internal/jwtauth/role_index_test.go
@@ -77,7 +77,7 @@ func TestRoleIndexer(t *testing.T) {
 		},
 	}
 
-	config := multiroleJWTConfig{
+	config := jwtAutoRolesConfig{
 		Roles: roles,
 	}
 


### PR DESCRIPTION
A few non-substantial left-overs from renaming the plugin