### PR TITLE
chore: add 'stas' as codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*	@statnett/stas


### PR DESCRIPTION
This will have effect if also enabling:

![image](https://github.com/statnett/renovate-presets/assets/104485047/ee3a7704-9d39-420e-b28d-9c31121035d8)