### PR TITLE
ci: fix broken links to reusable workflows

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -6,11 +6,11 @@ on:
     types:
       - opened
       - edited
+      - synchronize
 
 jobs:
   trigger:
-    uses: statnett/workflows/.github/workflows/lint-pr.yml@main
+    uses: statnett/github-workflows/.github/workflows/lint-pr.yaml@main
     permissions:
-      contents: read
       pull-requests: write
       statuses: write

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,10 +5,11 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   trigger:
-    uses: statnett/workflows/.github/workflows/release-please.yml@main
+    uses: statnett/github-workflows/.github/workflows/release-please.yaml@main
     secrets: inherit
     permissions:
       contents: write

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ bin/
 build/
 dist/
 config.json
+/.idea/
+*.iml


### PR DESCRIPTION
We have renamed the reusable GitHub workflow project and standardized on .yaml as file extensions. This updates what's needed to follow after.