### PR TITLE
feat: ability to set JWT claim used for alias

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ config:
 	for role in $(shell vault list -format=json auth/$(auth)/role | jq -r .[]); \
 	do vault read -format json "auth/$(auth)/role/$${role}" | jq "{\"$${role}\":.data.bound_claims}"; done \
 	| jq -s add \
-	| jq '{jwt_auth_host:"${VAULT_ADDR}",jwt_auth_path:"$(auth)",id_claim_key:"user_email",roles:.}' \
+	| jq '{jwt_auth_host:"${VAULT_ADDR}",jwt_auth_path:"$(auth)",user_claim:"user_email",roles:.}' \
 	> config.json
 
 .PHONY: configure

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ config:
 	for role in $(shell vault list -format=json auth/$(auth)/role | jq -r .[]); \
 	do vault read -format json "auth/$(auth)/role/$${role}" | jq "{\"$${role}\":.data.bound_claims}"; done \
 	| jq -s add \
-	| jq '{jwt_auth_host:"${VAULT_ADDR}",jwt_auth_path:"$(auth)",roles:.}' \
+	| jq '{jwt_auth_host:"${VAULT_ADDR}",jwt_auth_path:"$(auth)",id_claim_key:"user_email",roles:.}' \
 	> config.json
 
 .PHONY: configure

--- a/internal/jwtauth/backend_utils_test.go
+++ b/internal/jwtauth/backend_utils_test.go
@@ -50,5 +50,6 @@ func testConfig() map[string]any {
 		},
 		"jwt_auth_host": "http://localhost:8200",
 		"jwt_auth_path": "foo/jwt",
+		"id_claim_key":  "user_email",
 	}
 }

--- a/internal/jwtauth/backend_utils_test.go
+++ b/internal/jwtauth/backend_utils_test.go
@@ -50,6 +50,6 @@ func testConfig() map[string]any {
 		},
 		"jwt_auth_host": "http://localhost:8200",
 		"jwt_auth_path": "foo/jwt",
-		"id_claim_key":  "user_email",
+		"user_claim":    "user_email",
 	}
 }

--- a/internal/jwtauth/path_config.go
+++ b/internal/jwtauth/path_config.go
@@ -54,7 +54,7 @@ func pathConfig(backend *jwtAutoRolesAuthBackend) *framework.Path {
 			"user_claim": {
 				Type: framework.TypeString,
 				DisplayAttrs: &framework.DisplayAttributes{
-					Name: "Claim in JWT claims to use for auth alias name",
+					Name: "Claim in JWT claims to use for entity alias name",
 				},
 			},
 		},

--- a/internal/jwtauth/path_config.go
+++ b/internal/jwtauth/path_config.go
@@ -54,7 +54,7 @@ func pathConfig(backend *jwtAutoRolesAuthBackend) *framework.Path {
 			"user_claim": {
 				Type: framework.TypeString,
 				DisplayAttrs: &framework.DisplayAttributes{
-					Name: "Key in JWT claims to use for auth alias id",
+					Name: "Claim in JWT claims to use for user/username",
 				},
 			},
 		},

--- a/internal/jwtauth/path_config.go
+++ b/internal/jwtauth/path_config.go
@@ -54,7 +54,7 @@ func pathConfig(backend *jwtAutoRolesAuthBackend) *framework.Path {
 			"user_claim": {
 				Type: framework.TypeString,
 				DisplayAttrs: &framework.DisplayAttributes{
-					Name: "Claim in JWT claims to use for user/username",
+					Name: "Claim in JWT claims to use for auth alias name",
 				},
 			},
 		},

--- a/internal/jwtauth/path_config.go
+++ b/internal/jwtauth/path_config.go
@@ -26,7 +26,7 @@ type jwtAutoRolesConfig struct {
 	Roles       map[string]any `json:"roles"`
 	JWTAuthHost string         `json:"jwt_auth_host"`
 	JWTAuthPath string         `json:"jwt_auth_path"`
-	IDClaimKey  string         `json:"id_claim_key"`
+	UserClaim   string         `json:"user_claim"`
 }
 
 func pathConfig(backend *jwtAutoRolesAuthBackend) *framework.Path {
@@ -51,7 +51,7 @@ func pathConfig(backend *jwtAutoRolesAuthBackend) *framework.Path {
 					Name: "Path of the default jwt auth plugin (without 'auth' or 'login')",
 				},
 			},
-			"id_claim_key": {
+			"user_claim": {
 				Type: framework.TypeString,
 				DisplayAttrs: &framework.DisplayAttributes{
 					Name: "Key in JWT claims to use for auth alias id",
@@ -111,7 +111,7 @@ func (b *jwtAutoRolesAuthBackend) pathConfigWrite(
 		Roles:       d.Get("roles").(map[string]any),
 		JWTAuthHost: d.Get("jwt_auth_host").(string),
 		JWTAuthPath: d.Get("jwt_auth_path").(string),
-		IDClaimKey:  d.Get("id_claim_key").(string),
+		UserClaim:   d.Get("user_claim").(string),
 	}
 
 	_, err := parseRoles(&config)
@@ -147,7 +147,7 @@ func (b *jwtAutoRolesAuthBackend) pathConfigRead(
 			"roles":         config.Roles,
 			"jwt_auth_host": config.JWTAuthHost,
 			"jwt_auth_path": config.JWTAuthPath,
-			"id_claim_key":  config.IDClaimKey,
+			"user_claim":    config.UserClaim,
 		},
 	}, nil
 }

--- a/internal/jwtauth/path_config.go
+++ b/internal/jwtauth/path_config.go
@@ -26,6 +26,7 @@ type jwtAutoRolesConfig struct {
 	Roles       map[string]any `json:"roles"`
 	JWTAuthHost string         `json:"jwt_auth_host"`
 	JWTAuthPath string         `json:"jwt_auth_path"`
+	IDClaimKey  string         `json:"id_claim_key"`
 }
 
 func pathConfig(backend *jwtAutoRolesAuthBackend) *framework.Path {
@@ -48,6 +49,12 @@ func pathConfig(backend *jwtAutoRolesAuthBackend) *framework.Path {
 				Type: framework.TypeString,
 				DisplayAttrs: &framework.DisplayAttributes{
 					Name: "Path of the default jwt auth plugin (without 'auth' or 'login')",
+				},
+			},
+			"id_claim_key": {
+				Type: framework.TypeString,
+				DisplayAttrs: &framework.DisplayAttributes{
+					Name: "Key in JWT claims to use for EntityID",
 				},
 			},
 		},
@@ -104,6 +111,7 @@ func (b *jwtAutoRolesAuthBackend) pathConfigWrite(
 		Roles:       d.Get("roles").(map[string]any),
 		JWTAuthHost: d.Get("jwt_auth_host").(string),
 		JWTAuthPath: d.Get("jwt_auth_path").(string),
+		IDClaimKey:  d.Get("id_claim_key").(string),
 	}
 
 	_, err := parseRoles(&config)
@@ -139,6 +147,7 @@ func (b *jwtAutoRolesAuthBackend) pathConfigRead(
 			"roles":         config.Roles,
 			"jwt_auth_host": config.JWTAuthHost,
 			"jwt_auth_path": config.JWTAuthPath,
+			"id_claim_key":  config.IDClaimKey,
 		},
 	}, nil
 }

--- a/internal/jwtauth/path_config.go
+++ b/internal/jwtauth/path_config.go
@@ -54,7 +54,7 @@ func pathConfig(backend *jwtAutoRolesAuthBackend) *framework.Path {
 			"id_claim_key": {
 				Type: framework.TypeString,
 				DisplayAttrs: &framework.DisplayAttributes{
-					Name: "Key in JWT claims to use for EntityID",
+					Name: "Key in JWT claims to use for auth alias id",
 				},
 			},
 		},

--- a/internal/jwtauth/path_config_test.go
+++ b/internal/jwtauth/path_config_test.go
@@ -35,7 +35,7 @@ func TestConfig_Write(t *testing.T) {
 		Roles:       configData["roles"].(map[string]any),
 		JWTAuthHost: "http://localhost:8200",
 		JWTAuthPath: "foo/jwt",
-		IDClaimKey:  "user_email",
+		UserClaim:   "user_email",
 	}
 
 	if !reflect.DeepEqual(expected, conf) {

--- a/internal/jwtauth/path_config_test.go
+++ b/internal/jwtauth/path_config_test.go
@@ -35,6 +35,7 @@ func TestConfig_Write(t *testing.T) {
 		Roles:       configData["roles"].(map[string]any),
 		JWTAuthHost: "http://localhost:8200",
 		JWTAuthPath: "foo/jwt",
+		IDClaimKey:  "user_email",
 	}
 
 	if !reflect.DeepEqual(expected, conf) {

--- a/internal/jwtauth/path_login.go
+++ b/internal/jwtauth/path_login.go
@@ -67,7 +67,7 @@ func (b *jwtAutoRolesAuthBackend) pathLogin(
 	}
 
 	var alias *logical.Alias
-	if id, ok := claims[config.IDClaimKey].(string); ok {
+	if id, ok := claims[config.UserClaim].(string); ok {
 		alias = &logical.Alias{
 			Name: id,
 		}

--- a/internal/jwtauth/path_login.go
+++ b/internal/jwtauth/path_login.go
@@ -66,6 +66,8 @@ func (b *jwtAutoRolesAuthBackend) pathLogin(
 		return nil, fmt.Errorf("failed to parse token: %w", err)
 	}
 
+	entityID, _ := claims[config.IDClaimKey].(string)
+
 	roles := roleIndex.claimsRoles(claims)
 	policies, err := b.policies(ctx, config, roles, token)
 	if err != nil {
@@ -74,6 +76,7 @@ func (b *jwtAutoRolesAuthBackend) pathLogin(
 
 	return &logical.Response{
 		Auth: &logical.Auth{
+			EntityID: entityID,
 			Period:   time.Hour,
 			Policies: policies,
 		},

--- a/internal/jwtauth/path_login.go
+++ b/internal/jwtauth/path_login.go
@@ -66,7 +66,12 @@ func (b *jwtAutoRolesAuthBackend) pathLogin(
 		return nil, fmt.Errorf("failed to parse token: %w", err)
 	}
 
-	entityID, _ := claims[config.IDClaimKey].(string)
+	var alias *logical.Alias
+	if id, ok := claims[config.IDClaimKey].(string); ok {
+		alias = &logical.Alias{
+			Name: id,
+		}
+	}
 
 	roles := roleIndex.claimsRoles(claims)
 	policies, err := b.policies(ctx, config, roles, token)
@@ -76,7 +81,7 @@ func (b *jwtAutoRolesAuthBackend) pathLogin(
 
 	return &logical.Response{
 		Auth: &logical.Auth{
-			EntityID: entityID,
+			Alias:    alias,
 			Period:   time.Hour,
 			Policies: policies,
 		},


### PR DESCRIPTION
So that the Alias/EntityID can be configured based on some value in the incoming JWT claims, and an ID is not generated based on policies and namespace

ref https://github.com/hashicorp/vault/blob/594d304f25cb78d81cdaf0314cfc6ae773851299/sdk/logical/token.go#L184-L191  
similarly to https://github.com/hashicorp/vault-plugin-auth-jwt/blob/ab76cf59ee3962b406c617fcc6b8d4ee1dbdcb6e/path_login.go#L218-L255