### PR TITLE
refactor: role and policy fetchers

### DIFF
--- a/internal/jwtauth/path_config_roles_refresh_test.go
+++ b/internal/jwtauth/path_config_roles_refresh_test.go
@@ -31,7 +31,7 @@ func TestConfigRolesRefresh_Write(t *testing.T) {
 			"project_path": []any{"foo", "bar"},
 		},
 	}
-	var roleClient fakeRoleFetcher = func(_ context.Context, vaultToken string) (map[string]any, error) {
+	var roleClient fakeRoleFetcher = func(_ context.Context, _ *jwtAutoRolesConfig, vaultToken string) (map[string]any, error) {
 		return newRoles, nil
 	}
 	backend.roleClient = roleClient
@@ -60,8 +60,8 @@ func TestConfigRolesRefresh_Write(t *testing.T) {
 	}
 }
 
-type fakeRoleFetcher func(ctx context.Context, vaultToken string) (map[string]any, error)
+type fakeRoleFetcher func(context.Context, *jwtAutoRolesConfig, string) (map[string]any, error)
 
-func (c fakeRoleFetcher) roles(ctx context.Context, vaultToken string) (map[string]any, error) {
-	return c(ctx, vaultToken)
+func (c fakeRoleFetcher) roles(ctx context.Context, config *jwtAutoRolesConfig, vaultToken string) (map[string]any, error) {
+	return c(ctx, config, vaultToken)
 }

--- a/internal/jwtauth/path_config_test.go
+++ b/internal/jwtauth/path_config_test.go
@@ -52,7 +52,7 @@ func TestConfig_WriteWithToken(t *testing.T) {
 	delete(configData, "roles")
 
 	backend, storage := createTestBackend(t)
-	var roleClient fakeRoleFetcher = func(_ context.Context, vaultToken string) (map[string]any, error) {
+	var roleClient fakeRoleFetcher = func(_ context.Context, config *jwtAutoRolesConfig, vaultToken string) (map[string]any, error) {
 		return roles, nil
 	}
 	backend.roleClient = roleClient

--- a/internal/jwtauth/path_login.go
+++ b/internal/jwtauth/path_login.go
@@ -97,14 +97,9 @@ func (b *jwtAutoRolesAuthBackend) pathLogin(
 func (b *jwtAutoRolesAuthBackend) policies(
 	ctx context.Context, config *jwtAutoRolesConfig, roles []string, token string,
 ) ([]string, error) {
-	client, err := b.policyFetcher(config)
-	if err != nil {
-		return nil, err
-	}
-
 	policies := map[string]struct{}{}
 	for _, role := range roles {
-		rolePolicies, err := client.policies(ctx, schema.JwtLoginRequest{
+		rolePolicies, err := b.policyClient.policies(ctx, config, schema.JwtLoginRequest{
 			Jwt:  token,
 			Role: role,
 		})

--- a/internal/jwtauth/path_login_test.go
+++ b/internal/jwtauth/path_login_test.go
@@ -45,7 +45,7 @@ func TestLogin_Write(t *testing.T) {
 		t.Fatalf("err:%s resp:%#v\n", err, resp)
 	}
 
-	var policyClient fakePolicyFetcher = func(_ context.Context, request schema.JwtLoginRequest) ([]string, error) {
+	var policyClient fakePolicyFetcher = func(_ context.Context, _ *jwtAutoRolesConfig, request schema.JwtLoginRequest) ([]string, error) {
 		return []string{request.Role + "-policy"}, nil
 	}
 	backend.policyClient = policyClient
@@ -123,8 +123,8 @@ func TestLogin_Write(t *testing.T) {
 	}
 }
 
-type fakePolicyFetcher func(context.Context, schema.JwtLoginRequest) ([]string, error)
+type fakePolicyFetcher func(context.Context, *jwtAutoRolesConfig, schema.JwtLoginRequest) ([]string, error)
 
-func (c fakePolicyFetcher) policies(ctx context.Context, request schema.JwtLoginRequest) ([]string, error) {
-	return c(ctx, request)
+func (c fakePolicyFetcher) policies(ctx context.Context, config *jwtAutoRolesConfig, request schema.JwtLoginRequest) ([]string, error) {
+	return c(ctx, config, request)
 }


### PR DESCRIPTION
Remove the cached polcy and role clients. They don't need to be cached and can cause problem if not reset correctly, ref https://github.com/statnett/vault-plugin-auth-jwt-auto-roles/pull/83.

Resetting them may also cause issues in testing, where they are overwritten with fakes. This will therefore also work better with tests that reset the backend and then perform actions.