### PR TITLE
fix: bump to Go 1.24

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/statnett/vault-plugin-auth-jwt-auto-roles
 
-go 1.23.3
+go 1.24.0
 
 require (
 	github.com/go-test/deep v1.1.1


### PR DESCRIPTION
Mainly to mend https://github.com/statnett/vault-plugin-auth-jwt-auto-roles/pull/122.